### PR TITLE
Fix DapSetLogLevel when passing space after the level

### DIFF
--- a/plugin/dap.lua
+++ b/plugin/dap.lua
@@ -6,7 +6,7 @@ end
 local cmd = api.nvim_create_user_command
 cmd('DapSetLogLevel',
   function(opts)
-    require('dap').set_log_level(unpack(opts.fargs))
+    require('dap').set_log_level(vim.trim(opts.args))
   end,
   {
     nargs = 1,


### PR DESCRIPTION
if you passed a space after the level it should just work you did not add any letters and its not a script.
So I trimmed the function args, I also converted `unpack(opts.fargs)` to `opts.args` 

Note:
`opts.fargs` is table of the function args.
`unpack(table)` convert table to string.
`opts.args` is args as string.